### PR TITLE
Allow setting ember port other than 9000

### DIFF
--- a/emberOut.html
+++ b/emberOut.html
@@ -4,7 +4,8 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            clientIP: {value:""}
+            clientIP: {value:""},
+            emberPort: {value:"9000"}
         },
 
         inputs: 1,
@@ -25,8 +26,13 @@
         <label for="node-input-clientIP"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-clientIP" placeholder="Client IP">
     </div>
+    <div class="form-row">
+        <label for="node-input-emberPort"><i class="fa fa-tag"></i> Port</label>
+        <input type="text" id="node-input-emberPort" placeholder="ember Port">
+    </div>
 </script>
 
 <script type="text/html" data-help-name="ember-out">
     <p>A specialized node that takes OSC messages and sends it to a LAWO-console</p>
+    <p>Enter your console IP and Emberplus port, usually 9000 or 9001</p>
 </script>

--- a/emberOut.js
+++ b/emberOut.js
@@ -9,7 +9,7 @@ function EmberOut(config) {
     const node = this;
     let flowContext = this.context().flow;
 
-    const client = new EmberClient({ host: config.clientIP, port: 9000, logger: new LoggingService(5), timeoutValue: 5000 });
+    const client = new EmberClient({ host: config.clientIP, port: config.emberPort, logger: new LoggingService(5), timeoutValue: 5000 });
     console.log("created client");
     node.status({ fill: "yellow", shape: "dot", text: "Inject msg.topic reconnect to connect..." });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mikw99/nodered-osc-to-emberplus",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "a specialzed node to bridge osc-values to a lawo-console",
   "dependencies": {"@mikw99/node-emberplus-custom": "^1.0.0"},
   "main": "emberOut.js",


### PR DESCRIPTION
Adds an option in node config to enter in another TCP port for emberplus connection. 
Defaults to 9000